### PR TITLE
Fix: supported_color_modes needs to be a set, not a list

### DIFF
--- a/custom_components/omnilogic_local/light.py
+++ b/custom_components/omnilogic_local/light.py
@@ -82,7 +82,7 @@ class OmniLogicLightEntity(OmniLogicEntity[EntityIndexColorLogicLight], LightEnt
 
     _attr_effect_list = list(ColorLogicShow.__members__)
     _attr_supported_features = LightEntityFeature.EFFECT
-    _attr_supported_color_modes = [ColorMode.BRIGHTNESS]
+    _attr_supported_color_modes = {ColorMode.BRIGHTNESS}
 
     @property
     def is_on(self) -> bool | None:


### PR DESCRIPTION
Fixes the error when toggling lights that was reported in #86 and #85 