### PR TITLE
fix: Restore Idle button missing

### DIFF
--- a/custom_components/omnilogic_local/button.py
+++ b/custom_components/omnilogic_local/button.py
@@ -54,10 +54,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                 case FilterType.VARIABLE_SPEED:
                     entities.append(OmniLogicFilterButtonEntity(coordinator=coordinator, context=system_id, speed=speed))
 
-    async_add_entities(entities)
-
     _LOGGER.debug("Configuring button for restore idle with ID: %s", BACKYARD_SYSTEM_ID)
     entities.append(OmniLogicIdleButtonEntity(coordinator=coordinator, context=BACKYARD_SYSTEM_ID))
+
+    async_add_entities(entities)
 
 
 T = TypeVar("T", EntityIndexFilter, EntityIndexPump)


### PR DESCRIPTION
Really not sure how this ever worked... probably a race condition allowed it to work previously and the new crazy fast Home Assistant startup speed with 2024.3 exposed the problem.