### PR TITLE
fix: specify correct chlorinator settings, fixes #108

### DIFF
--- a/custom_components/omnilogic_local/coordinator.py
+++ b/custom_components/omnilogic_local/coordinator.py
@@ -1,4 +1,5 @@
 """Example integration using DataUpdateCoordinator."""
+
 from __future__ import annotations
 
 from collections.abc import Iterable
@@ -73,8 +74,10 @@ class OmniLogicCoordinator(DataUpdateCoordinator):
                 if SIMULATION:
                     _LOGGER.debug("Simulating Omni MSPConfig and Telemetry")
                     test_data = json.loads(TEST_DIAGNOSTIC_DATA.replace(r"\"", r"'"))
-                    self.msp_config = MSPConfig.load_xml(test_data["data"]["msp_config"])
-                    self.telemetry = Telemetry.load_xml(test_data["data"]["telemetry"])
+                    self.msp_config_xml = test_data["data"]["msp_config"]
+                    self.msp_config = MSPConfig.load_xml(self.msp_config_xml)
+                    self.telemetry_xml = test_data["data"]["telemetry"]
+                    self.telemetry = Telemetry.load_xml(self.telemetry_xml)
 
                 else:
                     # Initially we only pulled the msp_config at integration startup as it rarely changes

--- a/custom_components/omnilogic_local/manifest.json
+++ b/custom_components/omnilogic_local/manifest.json
@@ -13,9 +13,9 @@
   "issue_tracker": "https://github.com/cryptk/haomnilogic-local/issues",
   "loggers": ["pyomnilogic_local"],
   "requirements": [
-    "python_omnilogic_local==0.14.4"
+    "python_omnilogic_local==0.14.6"
   ],
   "ssdp": [],
-  "version": "0.7.7",
+  "version": "0.7.8",
   "zeroconf": []
 }

--- a/custom_components/omnilogic_local/number.py
+++ b/custom_components/omnilogic_local/number.py
@@ -283,5 +283,14 @@ class OmniLogicChlorinatorTimedPercentNumberEntity(OmniLogicEntity[EntityIndexCh
             case BodyOfWaterType.SPA:
                 bow_type = 1
 
-        await self.coordinator.omni_api.async_set_chlorinator_params(self.bow_id, self.system_id, int(value), bow_type=bow_type)
+        await self.coordinator.omni_api.async_set_chlorinator_params(
+            pool_id=self.bow_id,
+            equipment_id=self.system_id,
+            timed_percent=int(value),
+            cell_type=int(self.data.msp_config.cell_type),
+            op_mode=self.data.telemetry.operating_mode,
+            sc_timeout=self.data.msp_config.superchlor_timeout,
+            orp_timeout=self.data.msp_config.orp_timeout,
+            bow_type=bow_type,
+        )
         self.set_telemetry({"timed_percent": int(value)})

--- a/poetry.lock
+++ b/poetry.lock
@@ -2829,14 +2829,14 @@ six = ">=1.5"
 
 [[package]]
 name = "python-omnilogic-local"
-version = "0.14.3"
+version = "0.14.6"
 description = "A library for local control of Hayward OmniHub/OmniLogic pool controllers using their local API"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["dev"]
 files = [
-    {file = "python_omnilogic_local-0.14.3-py3-none-any.whl", hash = "sha256:e6c0a0e47e488f54cc7d470243772ad67b57678c366ebbff428829591bda13ce"},
-    {file = "python_omnilogic_local-0.14.3.tar.gz", hash = "sha256:2166ff50cb1230cea02fc02eaed694ca2252e2d662e122c21558d0873cba6370"},
+    {file = "python_omnilogic_local-0.14.6-py3-none-any.whl", hash = "sha256:06c80b0ef589e84f935520ba05104312998a64f98fa8c0baa8d35506d1c5dfbc"},
+    {file = "python_omnilogic_local-0.14.6.tar.gz", hash = "sha256:96ced40104d0c0f82a1efe79302f18894a19bb8de2e737e6d4f1620cb14205ba"},
 ]
 
 [package.dependencies]
@@ -3871,4 +3871,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.14"
-content-hash = "e0f646e69953ff04826326376ab99ffa9123d8bd320a70a95d4da0312ffed150"
+content-hash = "3d1f8d429fa2f0fa62abb1a6a4d6bb837a4c81daa9d2de3c4e31021850e40c97"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "haomnilogic-local"
-version = "0.7.7"
+version = "0.7.8"
 description = "A Home Assistant integration for Hayward OmniLogic/OmniHub pool controllers using the local UDP api"
 readme = "README.md"
 authors = [
@@ -21,7 +21,7 @@ package-mode = false
 pre-commit = "^3.0.0"
 mypy = "^1.2.0"
 homeassistant = "^2024.6.0"
-python_omnilogic_local = "0.14.3"
+python_omnilogic_local = "0.14.6"
 pylint = "^2.17.0"
 pydantic = "^1.10.7"
 pytest = "^7.3.1"


### PR DESCRIPTION
Specify parameters to the async_set_chlorinator_params function so that we don't accidentally change configuration when updating the chlorinator target percentage.