### PR TITLE
fix: adjust library name from underscores to hyphens

### DIFF
--- a/custom_components/omnilogic_local/manifest.json
+++ b/custom_components/omnilogic_local/manifest.json
@@ -1,9 +1,7 @@
 {
   "domain": "omnilogic_local",
   "name": "OmniLogic Local",
-  "codeowners": [
-    "@cryptk"
-  ],
+  "codeowners": ["@cryptk"],
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/cryptk/haomnilogic-local",
@@ -12,9 +10,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/cryptk/haomnilogic-local/issues",
   "loggers": ["pyomnilogic_local"],
-  "requirements": [
-    "python_omnilogic_local==0.22.0"
-  ],
+  "requirements": ["python-omnilogic-local==0.22.0"],
   "ssdp": [],
   "version": "0.0.0",
   "zeroconf": []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,14 +5,12 @@ description = "A Home Assistant integration for Hayward OmniLogic/OmniHub pool c
 readme = "README.md"
 requires-python = ">=3.14.2"
 authors = [
-    { name = "cryptk", email="cryptk@users.noreply.github.com"},
-    { name = "djtimca"},
-    { name = "garionphx"}
+    { name = "cryptk", email = "cryptk@users.noreply.github.com" },
+    { name = "djtimca" },
+    { name = "garionphx" },
 ]
 license-files = ["LICENSE"]
-dependencies = [
-    "python-omnilogic-local>=0.22.0",
-]
+dependencies = ["python-omnilogic-local>=0.22.0"]
 
 [project.urls]
 repository = "https://github.com/cryptk/haomnilogic-local"
@@ -29,15 +27,11 @@ dev = [
 ]
 
 [tool.codespell]
-ignore-words-list = [
-    "hass"
-]
+ignore-words-list = ["hass"]
 
 [tool.mypy]
 python_version = "3.14"
-plugins = [
-    "pydantic.mypy"
-]
+plugins = ["pydantic.mypy"]
 follow_imports = "normal"
 strict = true
 # warn_return_any = false
@@ -48,36 +42,36 @@ line-length = 140
 
 [tool.ruff.lint]
 select = [
-    "ERA",    # eradicate commented code
-    "ASYNC",  # flake8-async
-    "B",      # flake8-bugbear
-    "A",      # flake8-builtins
+    "ERA",   # eradicate commented code
+    "ASYNC", # flake8-async
+    "B",     # flake8-bugbear
+    "A",     # flake8-builtins
     # "EM",     # flake8-errmsg
     # "FIX",    # flake8-fixme
-    "ISC",    # flake8-implicit-str-concat
-    "ICN",    # flake8-import-conventions
-    "LOG",    # flake8-logging
-    "G",      # flake8-logging-format
-    "INP",    # flake8-no-pep420
-    "PIE",    # flake8-pie
-    "T20",    # flake8-print
-    "Q",      # flake8-quotes
-    "RSE",    # flake8-raise
-    "RET",    # flake8-return
+    "ISC", # flake8-implicit-str-concat
+    "ICN", # flake8-import-conventions
+    "LOG", # flake8-logging
+    "G",   # flake8-logging-format
+    "INP", # flake8-no-pep420
+    "PIE", # flake8-pie
+    "T20", # flake8-print
+    "Q",   # flake8-quotes
+    "RSE", # flake8-raise
+    "RET", # flake8-return
     # "SIM",    # flake8-simplify
     "PTH",    # flake8-use-pathlib
     "TID252", # flake8-tidy-imports
     # "TD",     # flake8-todos
     # "TC",     # flake8-type-checking
     # "ARG",    # flake8-unused-arguments
-    "I",      # isort
+    "I", # isort
     # "N",      # pep8-naming
     # "PERF",   # perflint
-    "E",      # pycodestyle errors
-    "W",      # pycodestyle warnings
+    "E", # pycodestyle errors
+    "W", # pycodestyle warnings
     # "DOC",   # pydoclint, only available with ruff preview mode enabled
     # "D",      # pydocstyle
-    "F",      # pyflakes
+    "F", # pyflakes
     # "UP",     # pyupgrade
     # "RUF",    # ruff-specific rules
     # "TRY",    # tryceratops

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,6 @@
-{ pkgs ? import <nixpkgs> {} }:
+{
+  pkgs ? import <nixpkgs> { },
+}:
 
 let
   shellInit = pkgs.writeText "haomnilogic-shell-init" ''
@@ -25,14 +27,15 @@ let
     echo "--- Activating Virtual Environment ---"
     source .venv/bin/activate
 
-    if [ ! -f dev_files/home-assistant-core/config/configuration.yaml ]; then
+    if ! command -v hass &> /dev/null; then
       echo "--- Setting Up Home Assistant Core ---"
       ./dev_files/home-assistant-core/script/setup
+    fi
+
+    if [ ! -L "dev_files/home-assistant-core/config/custom_components/omnilogic_local" ]; then
       echo "--- Adding OmniLogic Local Custom Component ---"
       mkdir -p dev_files/home-assistant-core/config/custom_components
-      if [ ! -L "dev_files/home-assistant-core/config/custom_components/omnilogic_local" ]; then
-        ln -s ../../../../custom_components/omnilogic_local dev_files/home-assistant-core/config/custom_components/omnilogic_local
-      fi
+      ln -s ../../../../custom_components/omnilogic_local dev_files/home-assistant-core/config/custom_components/omnilogic_local
     fi
 
     echo "--- Syncing Project Dependencies ---"
@@ -44,29 +47,30 @@ let
       uv pip install -e ../python-omnilogic-local
     fi
 
-    alias run-core="hass -c dev_files/home-assistant-core/config --skip-pip-packages python_omnilogic_local"
+    alias run-core="hass -c dev_files/home-assistant-core/config"
   '';
 in
 (pkgs.buildFHSEnv {
   name = "haomnilogic-fhs";
-  targetPkgs = pkgs: with pkgs; [
-    python314
-    uv
-    stdenv.cc.cc.lib
-    zlib
-    zlib.dev
-    bashInteractive
-    pkg-config
-    libffi
-    libffi.dev
-    openssl
-    openssl.dev
-    ffmpeg
-    gcc
-    autoconf
-    libjpeg_turbo
-    libpcap
-  ];
+  targetPkgs =
+    pkgs: with pkgs; [
+      python314
+      uv
+      stdenv.cc.cc.lib
+      zlib
+      zlib.dev
+      bashInteractive
+      pkg-config
+      libffi
+      libffi.dev
+      openssl
+      openssl.dev
+      ffmpeg
+      gcc
+      autoconf
+      libjpeg_turbo
+      libpcap
+    ];
 
   runScript = "bash --rcfile ${shellInit}";
 }).env


### PR DESCRIPTION
While reviewing #174 I noticed the code to convert the library name from hyphens to underscores. The name should be done with hyphens, and the only reason this worked before is because of https://peps.python.org/pep-0503/#normalized-names. The official and correct name of the distribution is python-omnilogic-local.

Adjust manifest.json to have correct library name using hyphens.