### PR TITLE
ci: modify how the backend library version is handled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,5 +41,7 @@ jobs:
           persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #6.2.0
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
       - name: Run prek
         uses: j178/prek-action@cbc2f23eb5539cf20d82d1aabd0d0ecbcc56f4e3 #v2.0.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,4 +56,4 @@ repos:
         name: manifest.json dependency version
         entry: scripts/check-manifest-version.sh
         language: script
-        files: ^manifest\.json|uv\.lock$
+        files: manifest\.json|uv\.lock$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     hooks:
       # Run the linter
       - id: ruff-check
-        args: [ --fix ]
+        args: [--fix]
       #  Run the formatter
       - id: ruff-format
         files: ^custom_components/.+\.(py|pyi)$
@@ -18,9 +18,9 @@ repos:
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
     rev: v1.24.1
     hooks:
-    - id: zizmor
-      args:
-        - --pedantic
+      - id: zizmor
+        args:
+          - --pedantic
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
@@ -39,7 +39,7 @@ repos:
     # uv version.
     rev: 0.11.6
     hooks:
-    - id: uv-lock
+      - id: uv-lock
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.20.1
     hooks:
@@ -48,5 +48,12 @@ repos:
           - "python_omnilogic_local==0.22.0"
           - "pytest>=8.0.0"
           - "homeassistant>=2025.1.2"
-        args: [ "--config-file=./pyproject.toml"]
+        args: ["--config-file=./pyproject.toml"]
         files: ^custom_components/.+\.(py|pyi)$
+  - repo: local
+    hooks:
+      - id: check-manifest
+        name: manifest.json dependency version
+        entry: scripts/check-manifest-version.sh
+        language: script
+        files: ^manifest\.json|uv\.lock$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "garionphx" },
 ]
 license-files = ["LICENSE"]
-dependencies = ["python-omnilogic-local>=0.22.0"]
+dependencies = ["python-omnilogic-local"]
 
 [project.urls]
 repository = "https://github.com/cryptk/haomnilogic-local"

--- a/scripts/check-manifest-version.sh
+++ b/scripts/check-manifest-version.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+MANIFEST_VERSION=$(jq -r .requirements[0] custom_components/omnilogic_local/manifest.json)
+PYPROJ_VERSION=$(uv export --frozen --no-hashes | grep ^python-omnilogic-local==)
+
+if [[ "${MANIFEST_VERSION}" == "${PYPROJ_VERSION}" ]]; then
+  echo "manifest.json version matches project version"
+  exit 0
+else
+  echo "manifest.json version appears to be out of date"
+  echo "Manifest version: ${MANIFEST_VERSION}"
+  echo "Project version: ${PYPROJ_VERSION}"
+  exit 1
+fi

--- a/shell.nix
+++ b/shell.nix
@@ -42,8 +42,8 @@ let
     # --inexact leaves any dependencies installed by Home Assistant alone
     uv sync --all-extras --inexact
 
-    if [ ! -f ../python-omnilogic-local ]; then
-      echo "--- Installing Development Backend Library ---"
+    if [ -d ../python-omnilogic-local ]; then
+      echo "--- Installing Backend Library In Editable Mode---"
       uv pip install -e ../python-omnilogic-local
     fi
 
@@ -70,6 +70,7 @@ in
       autoconf
       libjpeg_turbo
       libpcap
+      jq
     ];
 
   runScript = "bash --rcfile ${shellInit}";

--- a/uv.lock
+++ b/uv.lock
@@ -117,7 +117,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "python-omnilogic-local", specifier = ">=0.22.0" }]
+requires-dist = [{ name = "python-omnilogic-local" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
This modifies how we manage the backend library version. No longer specifying the version number in pyproject.toml which allows uv.lock to handle what version is installed while not having to modify the pyproject.toml to update the library.

It also adds a pre-commit check inspired by @m-d-brown to check that the library version specified in manifest.json matches the library version in uv.lock (which should be the version the integration was run against in development). This should catch cases where the integration was updated to a new library version but the manifest.json was not updated.