### PR TITLE
New config migrations

### DIFF
--- a/custom_components/omnilogic_local/__init__.py
+++ b/custom_components/omnilogic_local/__init__.py
@@ -5,14 +5,21 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from homeassistant.const import CONF_IP_ADDRESS, CONF_NAME, CONF_PORT, CONF_SCAN_INTERVAL, CONF_TIMEOUT, Platform
+from homeassistant.const import (
+    CONF_IP_ADDRESS,
+    CONF_NAME,
+    CONF_PORT,
+    CONF_SCAN_INTERVAL,
+    CONF_TIMEOUT,
+    Platform,
+)  # CONF_SCAN_INTERVAL kept for migration
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 from pyomnilogic_local import OmniLogic
 from pyomnilogic_local.omnitypes import OmniType
 
-from .const import BACKYARD_SYSTEM_ID, DEFAULT_SCAN_INTERVAL, DOMAIN, KEY_COORDINATOR
+from .const import BACKYARD_SYSTEM_ID, DOMAIN, KEY_COORDINATOR
 from .coordinator import OmniLogicCoordinator
 
 if TYPE_CHECKING:
@@ -45,7 +52,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise ConfigEntryNotReady from error
 
     # Create our data coordinator
-    coordinator = OmniLogicCoordinator(hass=hass, omni=omni, scan_interval=entry.data[CONF_SCAN_INTERVAL])
+    coordinator = OmniLogicCoordinator(hass=hass, omni=omni)
     await coordinator.async_config_entry_first_refresh()
 
     device_registry = dr.async_get(hass)
@@ -97,7 +104,8 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
 
     if config_entry.version == 1:
         new = {**config_entry.data}
-        new[CONF_SCAN_INTERVAL] = DEFAULT_SCAN_INTERVAL
+        # The migration to VERSION 4 removes this, but we need to add it here to migrate from version 1 to version 2
+        new[CONF_SCAN_INTERVAL] = 10
 
         hass.config_entries.async_update_entry(config_entry, data=new, version=2)
 
@@ -159,6 +167,10 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             entity_registry.async_update_entity(entity.entity_id, new_unique_id=new_unique_id)
 
         hass.config_entries.async_update_entry(config_entry, version=3)
+
+    if config_entry.version == 3:
+        new = {k: v for k, v in config_entry.data.items() if k != CONF_SCAN_INTERVAL}
+        hass.config_entries.async_update_entry(config_entry, data=new, version=4)
 
     _LOGGER.info("Migration to version %s successful", config_entry.version)
 

--- a/custom_components/omnilogic_local/__init__.py
+++ b/custom_components/omnilogic_local/__init__.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from homeassistant.const import CONF_IP_ADDRESS, CONF_NAME, CONF_PORT, CONF_SCAN_INTERVAL, CONF_TIMEOUT, Platform
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
 from pyomnilogic_local import OmniLogic
 from pyomnilogic_local.omnitypes import OmniType
 
@@ -138,6 +139,24 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
                     device.id,
                     new_identifiers=new_identifiers,
                 )
+
+        # Migrate entity unique_ids for backyard entities from "None X Y" to "-1 X Y"
+        entity_registry = er.async_get(hass)
+        entities = er.async_entries_for_config_entry(entity_registry, config_entry.entry_id)
+
+        for entity in entities:
+            parts = entity.unique_id.split(" ")
+            if parts[0] != "None":
+                continue
+            parts[0] = "-1"
+            new_unique_id = " ".join(parts)
+            _LOGGER.debug(
+                "Migrating entity %s unique_id from '%s' to '%s'",
+                entity.entity_id,
+                entity.unique_id,
+                new_unique_id,
+            )
+            entity_registry.async_update_entity(entity.entity_id, new_unique_id=new_unique_id)
 
         hass.config_entries.async_update_entry(config_entry, version=3)
 

--- a/custom_components/omnilogic_local/config_flow.py
+++ b/custom_components/omnilogic_local/config_flow.py
@@ -8,12 +8,12 @@ from typing import TYPE_CHECKING, Any
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from homeassistant.config_entries import ConfigFlow, OptionsFlow
-from homeassistant.const import CONF_IP_ADDRESS, CONF_NAME, CONF_PORT, CONF_SCAN_INTERVAL, CONF_TIMEOUT
+from homeassistant.const import CONF_IP_ADDRESS, CONF_NAME, CONF_PORT, CONF_TIMEOUT
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from pyomnilogic_local import OmniLogic
 
-from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, MIN_SCAN_INTERVAL
+from .const import DOMAIN
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry, ConfigFlowResult
@@ -27,7 +27,6 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
         vol.Required(CONF_IP_ADDRESS): cv.string,
         vol.Required(CONF_NAME, default="Omnilogic"): cv.string,
         vol.Optional(CONF_PORT, default=10444): cv.port,
-        vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): vol.All(cv.positive_int, vol.Clamp(min=MIN_SCAN_INTERVAL)),
         vol.Optional(CONF_TIMEOUT, default=5.0): vol.All(vol.Coerce(float), vol.Range(min=0.5, max=10.0)),
     }
 )
@@ -66,12 +65,6 @@ class OptionsFlowHandler(OptionsFlow):
                 {
                     vol.Required(CONF_IP_ADDRESS, default=self.config_entry.data[CONF_IP_ADDRESS]): cv.string,
                     vol.Required(CONF_PORT, default=self.config_entry.data[CONF_PORT]): cv.port,
-                    vol.Optional(
-                        CONF_SCAN_INTERVAL,
-                        description="bar",
-                        msg="foo",
-                        default=self.config_entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
-                    ): vol.All(cv.positive_int, vol.Clamp(min=MIN_SCAN_INTERVAL)),
                     vol.Required(CONF_TIMEOUT, default=self.config_entry.data[CONF_TIMEOUT]): vol.All(
                         vol.Coerce(float), vol.Range(min=0.5, max=10.0)
                     ),
@@ -83,7 +76,7 @@ class OptionsFlowHandler(OptionsFlow):
 class OmnilogicConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for OmniLogic Local."""
 
-    VERSION = 3
+    VERSION = 4
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Handle the initial step."""

--- a/custom_components/omnilogic_local/const.py
+++ b/custom_components/omnilogic_local/const.py
@@ -1,5 +1,6 @@
 """Constants for the OmniLogic Local integration."""
 
+from datetime import timedelta
 from typing import Final
 
 from pyomnilogic_local.omnitypes import OmniType
@@ -7,8 +8,7 @@ from pyomnilogic_local.omnitypes import OmniType
 DOMAIN: Final[str] = "omnilogic_local"
 KEY_COORDINATOR: Final[str] = "coordinator"
 
-DEFAULT_SCAN_INTERVAL: Final[int] = 10
-MIN_SCAN_INTERVAL: Final[int] = 5
+SCAN_INTERVAL = timedelta(seconds=10)
 UPDATE_DELAY_SECONDS: Final[float] = 1.5
 
 # According to Hayward docs, the backyard always has a system id of 0

--- a/custom_components/omnilogic_local/coordinator.py
+++ b/custom_components/omnilogic_local/coordinator.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import logging
-from datetime import timedelta
 from typing import TYPE_CHECKING
 
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import SCAN_INTERVAL
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -31,7 +32,7 @@ class OmniLogicCoordinator(DataUpdateCoordinator[None]):
     # We don't need to store the data inside of the coordinator
     data: None
 
-    def __init__(self, hass: HomeAssistant, omni: OmniLogic, scan_interval: int) -> None:
+    def __init__(self, hass: HomeAssistant, omni: OmniLogic) -> None:
         """Initialize my coordinator."""
         super().__init__(
             hass,
@@ -39,7 +40,7 @@ class OmniLogicCoordinator(DataUpdateCoordinator[None]):
             # Name of the data. For logging purposes.
             name="OmniLogic",
             # Polling interval. Will only be polled if there are subscribers.
-            update_interval=timedelta(seconds=scan_interval),
+            update_interval=SCAN_INTERVAL,
         )
         self.omni = omni
 

--- a/custom_components/omnilogic_local/strings.json
+++ b/custom_components/omnilogic_local/strings.json
@@ -7,7 +7,6 @@
           "ip_address": "[%key:common::config_flow::data::ip_address%]",
           "host": "[%key:common::config_flow::data::host%]",
           "port": "[%key:common::config_flow::data::port%]",
-          "scan_interval": "[%key:common::config_flow::data::scan_interval%]",
           "timeout": "[%key:common::config_flow::data::timeout%]"
         }
       }
@@ -29,7 +28,6 @@
           "ip_address": "[%key:common::options_flow::data::ip_address%]",
           "host": "[%key:common::config_flow::data::host%]",
           "port": "[%key:common::options_flow::data::port%]",
-          "scan_interval": "[%key:common::config_flow::data::scan_interval%]",
           "timeout": "[%key:common::options_flow::data::timeout%]"
         }
       }

--- a/custom_components/omnilogic_local/translations/en.json
+++ b/custom_components/omnilogic_local/translations/en.json
@@ -15,7 +15,6 @@
                     "ip_address": "IP Address",
                     "host": "Hostname/IP Address",
                     "port": "Port",
-                    "scan_interval": "Scan Interval",
                     "timeout": "Timeout"
                 }
             }
@@ -28,7 +27,6 @@
                     "ip_address": "IP Address",
                     "host": "Hostname/IP Address",
                     "port": "Port",
-                    "scan_interval": "Scan Interval",
                     "timeout": "Timeout"
                 }
             }


### PR DESCRIPTION
This fixes the entities in the backyard becoming orphaned on the update to 1.0.0.

It also removes the ability to configure the polling interval from the integration configuration/options in order to fall in line with integration best practices. If a user needs a different polling interval, they should disable polling in the integration system options and the configure an automation to trigger the refresh.

I know this will be annoying for some subset of users, but if I ever decide to upstream this provider into core, this would have to be done.