### PR TITLE
fix: correct update mechanism for temperature sensors

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,10 @@
   "mypy-type-checker.importStrategy": "fromEnvironment",
   "[python]": {
     "editor.defaultFormatter": "charliermarsh.ruff",
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": "explicit"
+    }
   },
   "[json][jsonc][yaml]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"

--- a/custom_components/omnilogic_local/manifest.json
+++ b/custom_components/omnilogic_local/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/cryptk/haomnilogic-local/issues",
   "loggers": ["pyomnilogic_local"],
-  "requirements": ["python-omnilogic-local==0.25.2"],
+  "requirements": ["python-omnilogic-local==0.26.0"],
   "ssdp": [],
   "version": "0.0.0",
   "zeroconf": []

--- a/custom_components/omnilogic_local/sensor.py
+++ b/custom_components/omnilogic_local/sensor.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar, cast
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
 from homeassistant.const import CONCENTRATION_PARTS_PER_MILLION, UnitOfPower, UnitOfTemperature
 from pyomnilogic_local import CSAD, Backyard, Bow, Chlorinator, Filter, HeaterEquipment, Sensor
 from pyomnilogic_local.omnitypes import ChlorinatorDispenserType, CSADType, FilterState, HeaterType, SensorType
 
-from .const import DOMAIN, KEY_COORDINATOR
+from .const import BACKYARD_SYSTEM_ID, DOMAIN, KEY_COORDINATOR
 from .entity import OmniLogicEntity
 
 if TYPE_CHECKING:
@@ -118,11 +118,15 @@ class OmniLogicTemperatureSensorEntity(OmniLogicEntity[Sensor], SensorEntity, Ge
 
     _attr_device_class = SensorDeviceClass.TEMPERATURE
     _attr_state_class = SensorStateClass.MEASUREMENT
-    sensed_equipment: SensedEquipmentT
+    sensed_id: int
 
     def __init__(self, coordinator: OmniLogicCoordinator, sensor: Sensor) -> None:
         """Pass coordinator to CoordinatorEntity."""
         super().__init__(coordinator, sensor)
+
+    @property
+    def sensed_equipment(self) -> SensedEquipmentT:
+        return cast(SensedEquipmentT, self.coordinator.omni.get_equipment_by_id(self.sensed_id))
 
     @property
     def native_unit_of_measurement(self) -> str | None:
@@ -138,9 +142,7 @@ class OmniLogicTemperatureSensorEntity(OmniLogicEntity[Sensor], SensorEntity, Ge
 class OmniLogicAirTemperatureSensorEntity(OmniLogicTemperatureSensorEntity[Backyard]):
     """Sensor entity for air temperature readings."""
 
-    def __init__(self, coordinator: OmniLogicCoordinator, sensor: Sensor) -> None:
-        super().__init__(coordinator, sensor)
-        self.sensed_equipment = coordinator.omni.backyard
+    sensed_id = BACKYARD_SYSTEM_ID
 
     @property
     def native_value(self) -> StateType | date | datetime | Decimal:
@@ -157,7 +159,7 @@ class OmniLogicWaterTemperatureSensorEntity(OmniLogicTemperatureSensorEntity[Bow
         if sensor.bow_id is None:
             msg = f"Sensor {sensor.name} does not have a bow_id"
             raise ValueError(msg)
-        self.sensed_equipment = coordinator.omni.backyard.bow[sensor.bow_id]
+        self.sensed_id = sensor.bow_id
 
     @property
     def native_value(self) -> StateType | date | datetime | Decimal:
@@ -170,7 +172,10 @@ class OmniLogicSolarTemperatureSensorEntity(OmniLogicTemperatureSensorEntity[Hea
 
     def __init__(self, coordinator: OmniLogicCoordinator, sensor: Sensor, heater_equipment: HeaterEquipment) -> None:
         super().__init__(coordinator, sensor)
-        self.sensed_equipment = heater_equipment
+        if heater_equipment.system_id is None:
+            msg = f"Solar heater {heater_equipment.name} does not have a system_id"
+            raise ValueError(msg)
+        self.sensed_id = heater_equipment.system_id
 
     @property
     def native_value(self) -> StateType | date | datetime | Decimal:

--- a/shell.nix
+++ b/shell.nix
@@ -47,7 +47,7 @@ let
       uv pip install -e ../python-omnilogic-local
     fi
 
-    alias run-core="hass -c dev_files/home-assistant-core/config"
+    alias run-core="hass -c dev_files/home-assistant-core/config" --skip-pip-packages python-omnilogic-local"
   '';
 in
 (pkgs.buildFHSEnv {

--- a/uv.lock
+++ b/uv.lock
@@ -329,15 +329,15 @@ wheels = [
 
 [[package]]
 name = "python-omnilogic-local"
-version = "0.25.2"
+version = "0.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "xmltodict" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a0/64/fe84888e6f9a32a46abbf908ff7f3be3a37e140021df6516b20414d6babd/python_omnilogic_local-0.25.2.tar.gz", hash = "sha256:a816c419335d154646f534d935e45685d2d12d30e19c9ea0d976b4a6e4584a0c", size = 82314, upload-time = "2026-04-16T23:55:42.743Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d7/86dd0ae0548c25abcbc41feda5c66e5d0dfb68746413a35ae1401f52caa1/python_omnilogic_local-0.26.0.tar.gz", hash = "sha256:ab525e24690d5dd520aca257c136da9c4f9478703467dca7b670aeff204fafbd", size = 82666, upload-time = "2026-04-20T18:28:17.938Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/00/64a99ff111e6c990735c59093ebbf1145537af21e6d55d47e876a1eabd59/python_omnilogic_local-0.25.2-py3-none-any.whl", hash = "sha256:1d5557af4d609ccec131d273055be373630b3505d9c6395476d0d3dfe8468749", size = 116621, upload-time = "2026-04-16T23:55:40.953Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/94/0c33e09933a7e93817b990c4ef0fa490b5e64ee60263c7b19612876fdf90/python_omnilogic_local-0.26.0-py3-none-any.whl", hash = "sha256:3c84eb94967ee3ffe839dea5b6ef145d9a1911d112fc3003e071395c06a16fe8", size = 116982, upload-time = "2026-04-20T18:28:16.315Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Temperature sensors don't report data from their own telemetry (they don't have any) but rather from other "sensed entities". This update corrects that behavior so they report off of the current live data rather than the data they were initialized with.