### PR TITLE
feat: fix unavailable state and add failure reason counts to diagnostics

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,8 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies:
-          - "python_omnilogic_local==0.22.0"
+          - "python-omnilogic-local>=0.27.0"
+          - "pydantic>=2.0.0"
           - "pytest>=8.0.0"
           - "homeassistant>=2025.1.2"
         args: ["--config-file=./pyproject.toml"]

--- a/custom_components/omnilogic_local/binary_sensor.py
+++ b/custom_components/omnilogic_local/binary_sensor.py
@@ -57,7 +57,8 @@ class OmniLogicServiceModeBinarySensorEntity(OmniLogicEntity[Backyard], BinarySe
     @property
     def available(self) -> bool:
         # This is one of the few things we can pull from the telemetry even if we are in service mode
-        return True
+        # This is only unavailable if the coordinator is unavailable (e.g. can't connect to the API at all)
+        return super().available
 
     @property
     def is_on(self) -> bool:

--- a/custom_components/omnilogic_local/coordinator.py
+++ b/custom_components/omnilogic_local/coordinator.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from pyomnilogic_local.api.exceptions import OmniFragmentationError, OmniMessageFormatError, OmniTimeoutError, OmniValidationError
 
 from .const import SCAN_INTERVAL
 
@@ -32,6 +33,8 @@ class OmniLogicCoordinator(DataUpdateCoordinator[None]):
     # We don't need to store the data inside of the coordinator
     data: None
 
+    failure_counts: dict[str, int] = {}
+
     def __init__(self, hass: HomeAssistant, omni: OmniLogic) -> None:
         """Initialize my coordinator."""
         super().__init__(
@@ -46,4 +49,17 @@ class OmniLogicCoordinator(DataUpdateCoordinator[None]):
 
     async def _async_update_data(self) -> None:
         """Update data via library."""
-        await self.omni.refresh(force=True)
+        try:
+            await self.omni.refresh(force=True)
+        except OmniFragmentationError as err:
+            self.failure_counts["connection"] = self.failure_counts.get("connection", 0) + 1
+            raise UpdateFailed("Failure to fragment or reassemble data to/from OmniLogic") from err
+        except OmniMessageFormatError as err:
+            self.failure_counts["format"] = self.failure_counts.get("format", 0) + 1
+            raise UpdateFailed("Received a malformed or invalid message from OmniLogic") from err
+        except OmniTimeoutError as err:
+            self.failure_counts["timeout"] = self.failure_counts.get("timeout", 0) + 1
+            raise UpdateFailed("Timeout occurred while fetching OmniLogic data") from err
+        except OmniValidationError as err:
+            self.failure_counts["validation"] = self.failure_counts.get("validation", 0) + 1
+            raise UpdateFailed("Received invalid data from OmniLogic") from err

--- a/custom_components/omnilogic_local/diagnostics.py
+++ b/custom_components/omnilogic_local/diagnostics.py
@@ -23,8 +23,9 @@ async def async_get_config_entry_diagnostics(hass: HomeAssistant, config_entry: 
 
     coordinator: OmniLogicCoordinator = hass.data[DOMAIN][config_entry.entry_id].get(KEY_COORDINATOR)
     if coordinator:
-        diag["msp_config"] = await coordinator.omni._api.async_get_mspconfig(raw=True)
-        diag["telemetry"] = await coordinator.omni._api.async_get_telemetry(raw=True)
+        diag["msp_config"] = coordinator.omni.mspconfig._raw
+        diag["telemetry"] = coordinator.omni.telemetry._raw
+        diag["failure_counts"] = coordinator.failure_counts
 
     # There are no credentials or other secrets within the diagnostic data for this integration
     return async_redact_data(diag, [])

--- a/custom_components/omnilogic_local/entity.py
+++ b/custom_components/omnilogic_local/entity.py
@@ -83,7 +83,7 @@ class OmniLogicEntity(CoordinatorEntity[OmniLogicCoordinator], Generic[Equipment
     def available(self) -> bool:
         # By default we consider an entity available if the backyard is ready (not in service mode),
         # Individual entities can override this if needed.
-        return self.equipment._omni.backyard.is_ready
+        return super().available and self.equipment._omni.backyard.is_ready  # Ensure coordinator is available, which checks if we have data
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/omnilogic_local/manifest.json
+++ b/custom_components/omnilogic_local/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/cryptk/haomnilogic-local/issues",
   "loggers": ["pyomnilogic_local"],
-  "requirements": ["python-omnilogic-local==0.26.0"],
+  "requirements": ["python-omnilogic-local==0.27.0"],
   "ssdp": [],
   "version": "0.0.0",
   "zeroconf": []

--- a/uv.lock
+++ b/uv.lock
@@ -329,15 +329,15 @@ wheels = [
 
 [[package]]
 name = "python-omnilogic-local"
-version = "0.26.0"
+version = "0.27.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "xmltodict" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0f/d7/86dd0ae0548c25abcbc41feda5c66e5d0dfb68746413a35ae1401f52caa1/python_omnilogic_local-0.26.0.tar.gz", hash = "sha256:ab525e24690d5dd520aca257c136da9c4f9478703467dca7b670aeff204fafbd", size = 82666, upload-time = "2026-04-20T18:28:17.938Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/52/4cc044ec7c355c20a2286d5fc6ac97f556d9f1faec609b627854f9489623/python_omnilogic_local-0.27.0.tar.gz", hash = "sha256:92dcf67e1bef1c8f6ba3e78b183525de15fe825952efca9ab6ed8892990e7cb2", size = 82725, upload-time = "2026-04-20T23:19:23.292Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/94/0c33e09933a7e93817b990c4ef0fa490b5e64ee60263c7b19612876fdf90/python_omnilogic_local-0.26.0-py3-none-any.whl", hash = "sha256:3c84eb94967ee3ffe839dea5b6ef145d9a1911d112fc3003e071395c06a16fe8", size = 116982, upload-time = "2026-04-20T18:28:16.315Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/ae/1b8121e4eaa66796665109a1dbe5a299c512232520b2a8f0378fece4c40b/python_omnilogic_local-0.27.0-py3-none-any.whl", hash = "sha256:bfb18cf0ead2833cd9e53cbbde129c885974d1868f5b1417332e3d9eb6cc65ec", size = 117269, upload-time = "2026-04-20T23:19:21.302Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This adds some enhanced logging when the update from the OmniLogic fails as well as tracks counts of reasons why updates failed and places them within the diagnostics data.