### PR TITLE
fix: update library to resolve infinite wait while waiting for response

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies:
-          - "python-omnilogic-local>=0.27.0"
+          - "python-omnilogic-local>=0.27.1"
           - "pydantic>=2.0.0"
           - "pytest>=8.0.0"
           - "homeassistant>=2025.1.2"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,8 @@
     "editor.defaultFormatter": "charliermarsh.ruff",
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-      "source.organizeImports": "explicit"
+      "source.organizeImports": "explicit",
+      "source.unusedImports": "explicit"
     }
   },
   "[json][jsonc][yaml]": {

--- a/custom_components/omnilogic_local/coordinator.py
+++ b/custom_components/omnilogic_local/coordinator.py
@@ -6,7 +6,6 @@ import logging
 from typing import TYPE_CHECKING
 
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from pyomnilogic_local.api.exceptions import OmniFragmentationError, OmniMessageFormatError, OmniTimeoutError, OmniValidationError
 
 from .const import SCAN_INTERVAL
 
@@ -51,15 +50,7 @@ class OmniLogicCoordinator(DataUpdateCoordinator[None]):
         """Update data via library."""
         try:
             await self.omni.refresh(force=True)
-        except OmniFragmentationError as err:
-            self.failure_counts["connection"] = self.failure_counts.get("connection", 0) + 1
-            raise UpdateFailed("Failure to fragment or reassemble data to/from OmniLogic") from err
-        except OmniMessageFormatError as err:
-            self.failure_counts["format"] = self.failure_counts.get("format", 0) + 1
-            raise UpdateFailed("Received a malformed or invalid message from OmniLogic") from err
-        except OmniTimeoutError as err:
-            self.failure_counts["timeout"] = self.failure_counts.get("timeout", 0) + 1
-            raise UpdateFailed("Timeout occurred while fetching OmniLogic data") from err
-        except OmniValidationError as err:
-            self.failure_counts["validation"] = self.failure_counts.get("validation", 0) + 1
-            raise UpdateFailed("Received invalid data from OmniLogic") from err
+        except Exception as err:
+            errName = type(err).__name__
+            self.failure_counts[errName] = self.failure_counts.get(errName, 0) + 1
+            raise UpdateFailed("Failed to update data from OmniLogic") from err

--- a/custom_components/omnilogic_local/coordinator.py
+++ b/custom_components/omnilogic_local/coordinator.py
@@ -51,6 +51,6 @@ class OmniLogicCoordinator(DataUpdateCoordinator[None]):
         try:
             await self.omni.refresh(force=True)
         except Exception as err:
-            errName = type(err).__name__
-            self.failure_counts[errName] = self.failure_counts.get(errName, 0) + 1
+            err_name = type(err).__name__
+            self.failure_counts[err_name] = self.failure_counts.get(err_name, 0) + 1
             raise UpdateFailed("Failed to update data from OmniLogic") from err

--- a/custom_components/omnilogic_local/manifest.json
+++ b/custom_components/omnilogic_local/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/cryptk/haomnilogic-local/issues",
   "loggers": ["pyomnilogic_local"],
-  "requirements": ["python-omnilogic-local==0.27.0"],
+  "requirements": ["python-omnilogic-local==0.27.1"],
   "ssdp": [],
   "version": "0.0.0",
   "zeroconf": []

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,1 @@
+sonar.python.version=3.14

--- a/uv.lock
+++ b/uv.lock
@@ -329,15 +329,15 @@ wheels = [
 
 [[package]]
 name = "python-omnilogic-local"
-version = "0.27.0"
+version = "0.27.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "xmltodict" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/52/4cc044ec7c355c20a2286d5fc6ac97f556d9f1faec609b627854f9489623/python_omnilogic_local-0.27.0.tar.gz", hash = "sha256:92dcf67e1bef1c8f6ba3e78b183525de15fe825952efca9ab6ed8892990e7cb2", size = 82725, upload-time = "2026-04-20T23:19:23.292Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/d4/9dd2c11e2c9b475c7b579094f70bb8cb0300ae57cfde71f19bc862240b11/python_omnilogic_local-0.27.1.tar.gz", hash = "sha256:3b62b93a6c53a95a0ed65d981560813279d50638abf4c89f646b1cb0bb71cca9", size = 83094, upload-time = "2026-04-22T00:11:43.459Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/ae/1b8121e4eaa66796665109a1dbe5a299c512232520b2a8f0378fece4c40b/python_omnilogic_local-0.27.0-py3-none-any.whl", hash = "sha256:bfb18cf0ead2833cd9e53cbbde129c885974d1868f5b1417332e3d9eb6cc65ec", size = 117269, upload-time = "2026-04-20T23:19:21.302Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c7/052b8ac183b9dc26b21f5a6e21d03cd56c6d11732263e3e0e702d3d1bd78/python_omnilogic_local-0.27.1-py3-none-any.whl", hash = "sha256:e1e20c26d2cf5bf2c020bba8835048b97217abc5edd6a7f8d9eee38952dd0549", size = 117672, upload-time = "2026-04-22T00:11:41.884Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
There was an odd condition when an OmniLogic has a flaky network connection that you could make a request that generates a response (more than just an ACK), and the OmniLogic sends the ACK, but never sends the followup response data. That would cause an infinite hang waiting for the response.

That has been resolved in the underlying library by applying a timeout to those waits (similar to the timeouts on waits for ACKs) allowing the library to recover from this condition.