### PR TITLE
feat: update library and handle delayed refresh better

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies:
-          - "python-omnilogic-local>=1.0.1"
+          - "python-omnilogic-local>=1.1.0"
           - "pydantic>=2.0.0"
           - "pytest>=8.0.0"
           - "homeassistant>=2025.1.2"

--- a/custom_components/omnilogic_local/button.py
+++ b/custom_components/omnilogic_local/button.py
@@ -87,7 +87,7 @@ class OmniLogicPumpButtonEntity(OmniLogicSpeedPresetButtonEntity[Pump]):
 
     async def async_press(self) -> None:
         await self.equipment.run_preset_speed(self.speed)
-        await self.schedule_delayed_update()
+        self.coordinator.do_next_refresh_after()
 
 
 class OmniLogicFilterButtonEntity(OmniLogicSpeedPresetButtonEntity[Filter]):
@@ -97,7 +97,7 @@ class OmniLogicFilterButtonEntity(OmniLogicSpeedPresetButtonEntity[Filter]):
 
     async def async_press(self) -> None:
         await self.equipment.run_preset_speed(self.speed)
-        await self.schedule_delayed_update()
+        self.coordinator.do_next_refresh_after()
 
 
 class OmniLogicIdleButtonEntity(OmniLogicEntity[Backyard], ButtonEntity):
@@ -112,4 +112,4 @@ class OmniLogicIdleButtonEntity(OmniLogicEntity[Backyard], ButtonEntity):
 
     async def async_press(self) -> None:
         await self.coordinator.omni._api.async_restore_idle_state()
-        await self.schedule_delayed_update()
+        self.coordinator.do_next_refresh_after()

--- a/custom_components/omnilogic_local/coordinator.py
+++ b/custom_components/omnilogic_local/coordinator.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import SCAN_INTERVAL
+from .const import SCAN_INTERVAL, UPDATE_DELAY_SECONDS
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -49,3 +49,11 @@ class OmniLogicCoordinator(DataUpdateCoordinator[None]):
             err_name = type(err).__name__
             self.failure_counts[err_name] = self.failure_counts.get(err_name, 0) + 1
             raise UpdateFailed("Failed to update data from OmniLogic") from err
+
+    def do_next_refresh_after(self, delay: float = UPDATE_DELAY_SECONDS) -> None:
+        """Delay the next refresh by a given number of seconds."""
+
+        _LOGGER.debug("Performing next refresh in %s seconds", delay)
+
+        self._retry_after = delay
+        self._schedule_refresh()

--- a/custom_components/omnilogic_local/entity.py
+++ b/custom_components/omnilogic_local/entity.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import logging
 from typing import Any, cast
 
@@ -25,7 +24,7 @@ from pyomnilogic_local import (
     Sensor,
 )
 
-from .const import BACKYARD_SYSTEM_ID, DOMAIN, MANUFACTURER, UPDATE_DELAY_SECONDS
+from .const import BACKYARD_SYSTEM_ID, DOMAIN, MANUFACTURER
 from .coordinator import OmniLogicCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -116,17 +115,3 @@ class OmniLogicEntity[EquipmentTypes: OmnilogicEquipment](CoordinatorEntity[Omni
     @property
     def unique_id(self) -> str | None:
         return f"{self.bow_id} {self.system_id} {self.name}"
-
-    @callback
-    async def schedule_delayed_update(self, delay: float = UPDATE_DELAY_SECONDS) -> None:
-        """Schedule a coordinator refresh after a short delay.
-
-        Call this at the end of any action method (async_turn_on, async_turn_off, etc.)
-        to give the OmniLogic time to reflect the change in its telemetry before we poll.
-        Any currently pending interval refresh is cancelled and rescheduled for `delay`
-        seconds from now, ensuring no back-to-back updates occur. The interval clock
-        resets naturally once the refresh completes.
-        """
-        _LOGGER.debug("Scheduling delayed update for %s in %s seconds", self.name, delay)
-        await asyncio.sleep(delay)
-        await self.coordinator.async_request_refresh()

--- a/custom_components/omnilogic_local/light.py
+++ b/custom_components/omnilogic_local/light.py
@@ -136,7 +136,7 @@ class OmniLogicLightEntity(OmniLogicEntity[ColorLogicLight], LightEntity):
             )
         except OmniEquipmentNotInitializedError as exc:
             raise HomeAssistantError("Light is not yet initialized, try again later.") from exc
-        await self.schedule_delayed_update()
+        self.coordinator.do_next_refresh_after()
 
     # The "Any" below here isn't great, we should create a type for this later
     async def async_turn_off(self, **kwargs: Any) -> None:
@@ -147,4 +147,4 @@ class OmniLogicLightEntity(OmniLogicEntity[ColorLogicLight], LightEntity):
         if not self.equipment.is_ready:
             raise HomeAssistantError("Light is in state %s and cannot be turned off yet, try again later." % str(self.equipment.state))
         await self.equipment.turn_off()
-        await self.schedule_delayed_update()
+        self.coordinator.do_next_refresh_after()

--- a/custom_components/omnilogic_local/manifest.json
+++ b/custom_components/omnilogic_local/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/cryptk/haomnilogic-local/issues",
   "loggers": ["pyomnilogic_local"],
-  "requirements": ["python-omnilogic-local==1.0.1"],
+  "requirements": ["python-omnilogic-local==1.1.0"],
   "ssdp": [],
   "version": "0.0.0",
   "zeroconf": []

--- a/custom_components/omnilogic_local/number.py
+++ b/custom_components/omnilogic_local/number.py
@@ -139,7 +139,7 @@ class OmniLogicVSPNumberEntity[PT: PumpTypes](OmniLogicEntity[PT], NumberEntity)
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
         await self.equipment.set_speed(int(value))
-        await self.schedule_delayed_update()
+        self.coordinator.do_next_refresh_after()
 
 
 class OmniLogicPumpNumberEntity(OmniLogicVSPNumberEntity[Pump]):
@@ -177,7 +177,7 @@ class OmniLogicSolarSetPointNumberEntity(OmniLogicEntity[Heater], NumberEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         await self.equipment.set_solar_temperature(int(value))
-        await self.schedule_delayed_update()
+        self.coordinator.do_next_refresh_after()
 
 
 class OmniLogicChlorinatorTimedPercentNumberEntity(OmniLogicEntity[Chlorinator], NumberEntity):
@@ -196,4 +196,4 @@ class OmniLogicChlorinatorTimedPercentNumberEntity(OmniLogicEntity[Chlorinator],
 
     async def async_set_native_value(self, value: float) -> None:
         await self.equipment.set_timed_percent(int(value))
-        await self.schedule_delayed_update()
+        self.coordinator.do_next_refresh_after()

--- a/custom_components/omnilogic_local/switch.py
+++ b/custom_components/omnilogic_local/switch.py
@@ -81,13 +81,13 @@ class OmniLogicRelaySwitchEntity(OmniLogicEntity[Relay], SwitchEntity):
         """Turn the entity on."""
         _LOGGER.debug("turning on relay ID: %s", self.system_id)
         await self.equipment.turn_on()
-        await self.schedule_delayed_update()
+        self.coordinator.do_next_refresh_after()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         _LOGGER.debug("turning off relay ID: %s", self.system_id)
         await self.equipment.turn_off()
-        await self.schedule_delayed_update()
+        self.coordinator.do_next_refresh_after()
 
 
 class OmniLogicPumpSwitchEntity(OmniLogicEntity[Pump], SwitchEntity):
@@ -108,13 +108,13 @@ class OmniLogicPumpSwitchEntity(OmniLogicEntity[Pump], SwitchEntity):
         """Turn the entity on."""
         _LOGGER.debug("turning on pump ID: %s", self.system_id)
         await self.equipment.turn_on()
-        await self.schedule_delayed_update()
+        self.coordinator.do_next_refresh_after()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         _LOGGER.debug("turning off pump ID: %s", self.system_id)
         await self.equipment.turn_off()
-        await self.schedule_delayed_update()
+        self.coordinator.do_next_refresh_after()
 
 
 class OmniLogicFilterSwitchEntity(OmniLogicEntity[Filter], SwitchEntity):
@@ -135,13 +135,13 @@ class OmniLogicFilterSwitchEntity(OmniLogicEntity[Filter], SwitchEntity):
         """Turn the entity on."""
         _LOGGER.debug("turning on filter ID: %s", self.system_id)
         await self.equipment.turn_on()
-        await self.schedule_delayed_update()
+        self.coordinator.do_next_refresh_after()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         _LOGGER.debug("turning off filter ID: %s", self.system_id)
         await self.equipment.turn_off()
-        await self.schedule_delayed_update()
+        self.coordinator.do_next_refresh_after()
 
     @property
     def _extra_state_attributes(self) -> dict[str, Any]:
@@ -169,13 +169,13 @@ class OmniLogicChlorinatorSwitchEntity(OmniLogicEntity[Chlorinator], SwitchEntit
         """Turn the entity on."""
         _LOGGER.debug("turning on chlorinator ID: %s", self.system_id)
         await self.equipment.turn_on()
-        await self.schedule_delayed_update()
+        self.coordinator.do_next_refresh_after()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         _LOGGER.debug("turning off chlorinator ID: %s", self.system_id)
         await self.equipment.turn_off()
-        await self.schedule_delayed_update()
+        self.coordinator.do_next_refresh_after()
 
 
 class OmniLogicSpilloverSwitchEntity(OmniLogicEntity[Bow], SwitchEntity):
@@ -203,10 +203,10 @@ class OmniLogicSpilloverSwitchEntity(OmniLogicEntity[Bow], SwitchEntity):
         """Turn the entity on."""
         _LOGGER.debug("turning on spillover ID: %s", self.system_id)
         await self.equipment.turn_on_spillover()
-        await self.schedule_delayed_update()
+        self.coordinator.do_next_refresh_after()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         _LOGGER.debug("turning off spillover ID: %s", self.system_id)
         await self.equipment.turn_off_spillover()
-        await self.schedule_delayed_update()
+        self.coordinator.do_next_refresh_after()

--- a/custom_components/omnilogic_local/valve.py
+++ b/custom_components/omnilogic_local/valve.py
@@ -79,10 +79,10 @@ class OmniLogicValveEntity(OmniLogicEntity[Relay], ValveEntity):
         """Open the valve."""
         _LOGGER.debug("opening valve ID: %s", self.system_id)
         await self.equipment.turn_on()
-        await self.schedule_delayed_update()
+        self.coordinator.do_next_refresh_after()
 
     async def async_close_valve(self, **kwargs: Any) -> None:
         """Close the valve."""
         _LOGGER.debug("closing valve ID: %s", self.system_id)
         await self.equipment.turn_off()
-        await self.schedule_delayed_update()
+        self.coordinator.do_next_refresh_after()

--- a/custom_components/omnilogic_local/water_heater.py
+++ b/custom_components/omnilogic_local/water_heater.py
@@ -80,7 +80,7 @@ class OmniLogicWaterHeaterEntity(OmniLogicEntity[Heater], WaterHeaterEntity):
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set target temperature."""
         await self.equipment.set_temperature(int(kwargs[ATTR_TEMPERATURE]))
-        await self.schedule_delayed_update()
+        self.coordinator.do_next_refresh_after()
 
     async def async_set_operation_mode(self, operation_mode: str) -> None:
         """Set operation mode."""
@@ -89,7 +89,7 @@ class OmniLogicWaterHeaterEntity(OmniLogicEntity[Heater], WaterHeaterEntity):
                 await self.equipment.turn_on()
             case "off":
                 await self.equipment.turn_off()
-        await self.schedule_delayed_update()
+        self.coordinator.do_next_refresh_after()
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         await self.async_set_operation_mode("on")

--- a/uv.lock
+++ b/uv.lock
@@ -329,15 +329,15 @@ wheels = [
 
 [[package]]
 name = "python-omnilogic-local"
-version = "1.0.1"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "xmltodict" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/32/e1b35696574ab7997a57f8eb3b42b1105afafd46fd14130c505b60c5e2b5/python_omnilogic_local-1.0.1.tar.gz", hash = "sha256:ce9c99c27148e438cae5a8ac7f1b4b94d6da1335ebf7d0f6c122e87be91991e2", size = 83240, upload-time = "2026-04-23T23:21:27.46Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/a4/7e31d946783dec4a230f6a1c786da4a424fd4ea9c05ac660a3e2379dad19/python_omnilogic_local-1.1.0.tar.gz", hash = "sha256:83dd9366816c8358884acf8c717b47d479f161f0909f971177a08bb8eeeccf34", size = 83123, upload-time = "2026-04-27T04:04:46.79Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/69/5d6c7617bba3f20c4b6fc8819554d0a56219c55daa0488e0b7b51f59ab66/python_omnilogic_local-1.0.1-py3-none-any.whl", hash = "sha256:c0df5102649622aa4a239c60522a2c5333dd2d8baefd6f46997c01c3a1cfde8e", size = 117756, upload-time = "2026-04-23T23:21:26.072Z" },
+    { url = "https://files.pythonhosted.org/packages/96/2c/8f274c4e0cff528ee72f09798c29d9e0a19db1e60015ded88197622d9cdc/python_omnilogic_local-1.1.0-py3-none-any.whl", hash = "sha256:4fd6811b2067d98dd1ee160015aef038a652a57bedb616c663a47f78c795f2a6", size = 118135, upload-time = "2026-04-27T04:04:45.322Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This updates the underlying library to address a couple of the leading causes of entities going unavailable, which was a failure of the library to properly retry message delivery/handling in some specific scenarios that happen under conditions where the underlying network is dropping packets at inopportune times.

It also updates how the delayed refresh after an action is performed to shift that burden to the coordinator rather than the entity itself.

refs: #234 