### PR TITLE
feat: csad dispensing sensor, fix filter turn_off, remove chlor op mode select

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies:
-          - "python-omnilogic-local>=3.0.0"
+          - "python-omnilogic-local>=3.1.0"
           - "pydantic>=2.0.0"
           - "pytest>=8.0.0"
           - "homeassistant>=2025.1.2"

--- a/custom_components/omnilogic_local/binary_sensor.py
+++ b/custom_components/omnilogic_local/binary_sensor.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass, BinarySensorEntity, BinarySensorEntityDescription
 from homeassistant.const import EntityCategory
-from pyomnilogic_local import Backyard, Bow, Chlorinator, HeaterEquipment
-from pyomnilogic_local.omnitypes import ChlorinatorAlert, ChlorinatorError, ChlorinatorStatus
+from pyomnilogic_local import CSAD, Backyard, Bow, Chlorinator, HeaterEquipment
+from pyomnilogic_local.omnitypes import ChlorinatorAlert, ChlorinatorError, ChlorinatorStatus, CSADStatus
 
 from .const import DOMAIN, KEY_COORDINATOR
 from .coordinator import OmniLogicCoordinator
@@ -63,6 +63,14 @@ CHLORINATOR_BINARY_SENSORS: tuple[OmniLogicBinarySensorEntityDescription, ...] =
     ),
 )
 
+CSAD_BINARY_SENSORS: tuple[OmniLogicBinarySensorEntityDescription, ...] = (
+    OmniLogicBinarySensorEntityDescription(
+        key="dispensing",
+        name="Dispensing",
+        value_fn=lambda equipment: (equipment.status is CSADStatus.DISPENSING) if isinstance(equipment, CSAD) else None,
+    ),
+)
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
     """Set up the switch platform."""
@@ -100,6 +108,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                 entity_description=description,
             )
             for description in CHLORINATOR_BINARY_SENSORS
+        )
+
+    # Create binary sensor entities for each CSAD based on the descriptions in CSAD_BINARY_SENSORS
+    for _, _, csad in coordinator.omni.all_csads.items():
+        entities.extend(
+            OmniLogicCsadBinarySensorEntity(
+                coordinator=coordinator,
+                equipment=csad,
+                entity_description=description,
+            )
+            for description in CSAD_BINARY_SENSORS
         )
 
     # Create binary sensor entities for each chlorinator status, alert, and error message
@@ -204,6 +223,31 @@ class OmniLogicChlorinatorBinarySensorEntity(OmniLogicEntity[Chlorinator], Binar
         self,
         coordinator: OmniLogicCoordinator,
         equipment: Chlorinator,
+        entity_description: OmniLogicBinarySensorEntityDescription,
+    ) -> None:
+        super().__init__(coordinator, equipment)
+        self.entity_description = entity_description
+        self._attr_name = f"{equipment.name} {str(entity_description.name)}" if hasattr(entity_description, "name") else None
+
+    @property
+    def _extra_state_attributes(self) -> dict[str, Any]:
+        return self.entity_description.extra_state_attributes_fn(self.equipment)
+
+    @property
+    def is_on(self) -> bool | None:
+        # Override the cached value with a dynamic value based on the entity description function
+        return self.entity_description.value_fn(self.equipment)
+
+
+class OmniLogicCsadBinarySensorEntity(OmniLogicEntity[CSAD], BinarySensorEntity):
+    """Binary sensor entity for CSAD status."""
+
+    entity_description: OmniLogicBinarySensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: OmniLogicCoordinator,
+        equipment: CSAD,
         entity_description: OmniLogicBinarySensorEntityDescription,
     ) -> None:
         super().__init__(coordinator, equipment)

--- a/custom_components/omnilogic_local/manifest.json
+++ b/custom_components/omnilogic_local/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/cryptk/haomnilogic-local/issues",
   "loggers": ["pyomnilogic_local"],
-  "requirements": ["python-omnilogic-local==3.0.0"],
+  "requirements": ["python-omnilogic-local==3.1.0"],
   "ssdp": [],
   "version": "0.0.0",
   "zeroconf": []

--- a/custom_components/omnilogic_local/select.py
+++ b/custom_components/omnilogic_local/select.py
@@ -5,9 +5,8 @@ from math import floor
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.select import SelectEntity
-from pyomnilogic_local import CSAD, Chlorinator, Filter, Pump
+from pyomnilogic_local import Filter, Pump
 from pyomnilogic_local.omnitypes import (
-    ChlorinatorMSPConfigMode,
     FilterSpeedPresets,
     FilterState,
     FilterType,
@@ -34,15 +33,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     coordinator: OmniLogicCoordinator = hass.data[DOMAIN][entry.entry_id][KEY_COORDINATOR]
     entities: list[SelectEntity] = []
 
-    # If we have a Chlorinator ...
-    for _, _, chlorinator in coordinator.omni.all_chlorinators.items():
-        # ... and we have a CSAD on the same BoW ...
-        if chlorinator.bow_id is not None and coordinator.omni.backyard.bow[chlorinator.bow_id].csad is not None:
-            # ... then we can support the ORP set point
-            csad = coordinator.omni.backyard.bow[chlorinator.bow_id].csad
-            if csad is not None:
-                entities.append(OmniLogicChlorinatorOpModeSelectEntity(coordinator=coordinator, equipment=chlorinator, csad=csad))
-
     for _, _, pump in coordinator.omni.all_pumps.items():
         if pump.equip_type == PumpType.DUAL_SPEED:
             entities.append(OmniLogicPumpSpeedSelectEntity(coordinator=coordinator, equipment=pump))
@@ -52,26 +42,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
             entities.append(OmniLogicFilterSpeedSelectEntity(coordinator=coordinator, equipment=filt))
 
     async_add_entities(entities)
-
-
-class OmniLogicChlorinatorOpModeSelectEntity(OmniLogicEntity[Chlorinator], SelectEntity):
-    """Number entity for CSAD pH control."""
-
-    _attr_name = "Chlorinator Operating Mode"
-    _attr_options = [str(mode) for mode in (ChlorinatorMSPConfigMode.TIMED, ChlorinatorMSPConfigMode.ORP_AUTO)]
-
-    def __init__(self, coordinator: OmniLogicCoordinator, equipment: Chlorinator, csad: CSAD):
-        super().__init__(coordinator, equipment)
-        self._csad = csad
-
-    @property
-    def current_option(self) -> str:
-        return str(self.equipment.mode)
-
-    async def async_select_option(self, option: str) -> None:
-        new_op_mode = ChlorinatorMSPConfigMode.from_str(option)
-        await self.equipment.set_op_mode(new_op_mode)
-        self.coordinator.do_next_refresh_after()
 
 
 type PumpTypes = Pump | Filter

--- a/uv.lock
+++ b/uv.lock
@@ -329,15 +329,15 @@ wheels = [
 
 [[package]]
 name = "python-omnilogic-local"
-version = "3.0.0"
+version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "xmltodict" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/f5/3dbc9f071a0976482135c0644509609c3dd5a27695bbd82e955b08680430/python_omnilogic_local-3.0.0.tar.gz", hash = "sha256:fe01c2fa428df72f57a25657ffc65488a707400688230c4d0f2d79ec9be8bc34", size = 84495, upload-time = "2026-05-09T21:48:09.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/52/d4fc0385e6a60e3d6e4c1691067816689324e88920adab6f17479ac8a4f0/python_omnilogic_local-3.1.0.tar.gz", hash = "sha256:fab74177333bc641c3e4f724a4be9e725c10d2817b9e227ce1217d942948cc17", size = 84755, upload-time = "2026-05-12T04:22:22.936Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/1f/8c70945891b4b50fe2c62d60960f6dd9457fc54d41dcced81754739521c2/python_omnilogic_local-3.0.0-py3-none-any.whl", hash = "sha256:683b1fa27df3a0c3928d312685d26769a9882a5ef952c7fc8733d5a63adc6019", size = 119097, upload-time = "2026-05-09T21:48:07.967Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/30/23bacb05b0d5be26edf52b4d23c358593e5d12cf95fa2b254e64bdb87fdc/python_omnilogic_local-3.1.0-py3-none-any.whl", hash = "sha256:dc0608edc4fbe0796f0f31b3792e522ceedb2ee0934b497ee59fcd445f834a7a", size = 119357, upload-time = "2026-05-12T04:22:21.105Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This adds a binary_sensor for the pH Dosing status as requested in #150
This enabled turning off a filter pump while it's in priming mode, fixes: #203 
This removes the Chlorinator Operating Mode select entity, it isn't working properly. Will have to re-introduce it later after it is figured out better how to change the mode between Timed-Percent and ORP Auto