### PR TITLE
feat: update underlying library and do some code cleanup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies:
-          - "python-omnilogic-local>=3.1.0"
+          - "python-omnilogic-local>=5.0.0"
           - "pydantic>=2.0.0"
           - "pytest>=8.0.0"
           - "homeassistant>=2025.1.2"

--- a/custom_components/omnilogic_local/__init__.py
+++ b/custom_components/omnilogic_local/__init__.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
-from pyomnilogic_local import OmniLogic
+from pyomnilogic_local import OmniLogic, OmniLogicConfig
 from pyomnilogic_local.omnitypes import OmniType
 
 from .const import BACKYARD_SYSTEM_ID, DOMAIN, KEY_COORDINATOR, SUGGESTED_AREA
@@ -44,7 +44,15 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up OmniLogic Local from a config entry."""
     # Create an API instance
-    omni = OmniLogic(entry.data[CONF_IP_ADDRESS], entry.data[CONF_PORT], entry.data[CONF_TIMEOUT])
+    omni_config = OmniLogicConfig(
+        host=entry.data[CONF_IP_ADDRESS],
+        port=entry.data[CONF_PORT],
+        timeout=entry.data[CONF_TIMEOUT],
+        # The Home Assistant integration only references OmniLogic equipment by their ID number so we
+        # can squelch the warning about duplicate equipment names
+        warn_duplicate_equipment_names=False,
+    )
+    omni = OmniLogic(omni_config)
 
     # Validate that we can talk to the API endpoint
     try:

--- a/custom_components/omnilogic_local/config_flow.py
+++ b/custom_components/omnilogic_local/config_flow.py
@@ -11,7 +11,7 @@ from homeassistant.config_entries import ConfigFlow, OptionsFlow
 from homeassistant.const import CONF_IP_ADDRESS, CONF_NAME, CONF_PORT, CONF_TIMEOUT
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
-from pyomnilogic_local import OmniLogic
+from pyomnilogic_local import OmniLogic, OmniLogicConfig
 
 from .const import DOMAIN
 
@@ -36,7 +36,15 @@ async def validate_input(data: dict[str, Any]) -> None:
 
     Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
     """
-    omni = OmniLogic(data[CONF_IP_ADDRESS], data[CONF_PORT], data[CONF_TIMEOUT])
+    omni_config = OmniLogicConfig(
+        host=data[CONF_IP_ADDRESS],
+        port=data[CONF_PORT],
+        timeout=data[CONF_TIMEOUT],
+        # The Home Assistant integration only references OmniLogic equipment by their ID number so we
+        # can squelch the warning about duplicate equipment names
+        warn_duplicate_equipment_names=False,
+    )
+    omni = OmniLogic(omni_config)
     try:
         await omni.refresh()
     except TimeoutError as exc:

--- a/custom_components/omnilogic_local/light.py
+++ b/custom_components/omnilogic_local/light.py
@@ -63,8 +63,8 @@ class OmniLogicLightEntity(OmniLogicEntity[ColorLogicLight], LightEntity):
     def is_on(self) -> bool | None:
         return self.equipment.state not in [
             ColorLogicPowerState.OFF,
-            ColorLogicPowerState.POWERING_OFF,
-            ColorLogicPowerState.COOLDOWN,
+            ColorLogicPowerState.WAIT_POWER_DOWN,
+            ColorLogicPowerState.POWER_DOWN,
         ]
 
     @property

--- a/custom_components/omnilogic_local/manifest.json
+++ b/custom_components/omnilogic_local/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/cryptk/haomnilogic-local/issues",
   "loggers": ["pyomnilogic_local"],
-  "requirements": ["python-omnilogic-local==3.1.0"],
+  "requirements": ["python-omnilogic-local==5.0.0"],
   "ssdp": [],
   "version": "0.0.0",
   "zeroconf": []

--- a/custom_components/omnilogic_local/number.py
+++ b/custom_components/omnilogic_local/number.py
@@ -9,7 +9,7 @@ from homeassistant.const import PERCENTAGE, UnitOfElectricPotential, UnitOfTempe
 from pyomnilogic_local import CSAD, Chlorinator, Filter, Heater, Pump
 from pyomnilogic_local.omnitypes import (
     ChlorinatorDispenserType,
-    ChlorinatorMSPConfigMode,
+    ChlorinatorMode,
     FilterType,
     HeaterType,
     PumpType,
@@ -165,7 +165,13 @@ class OmniLogicChlorinatorTimedPercentNumberEntity(OmniLogicEntity[Chlorinator],
     @property
     def available(self) -> bool:
         # This entity is only available if we have a chlorinator in TIMED mode
-        return super().available and self.equipment.mode == ChlorinatorMSPConfigMode.TIMED
+        return super().available and self.equipment.mode == ChlorinatorMode.TIMED
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        # It's not super common for people to change the mode of their chlorinator, so we only enable
+        # the relevant entity by default based on the mode the chlorinator is in
+        return self.equipment.mode == ChlorinatorMode.TIMED
 
     @property
     def native_value(self) -> float | None:
@@ -197,7 +203,15 @@ class OmniLogicCSADORPNumberEntity(OmniLogicEntity[CSAD], NumberEntity):
         # This entity is only available if we have a chlorinator in ORP_AUTO mode, which means we have a CSAD to control it
         if self._chlorinator is None:
             return False
-        return super().available and self._chlorinator.mode == ChlorinatorMSPConfigMode.ORP_AUTO
+        return super().available and self._chlorinator.mode == ChlorinatorMode.ORP_AUTO
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        # It's not super common for people to change the mode of their chlorinator, so we only enable
+        # the relevant entity by default based on the mode the chlorinator is in
+        if self._chlorinator is None:
+            return False
+        return self._chlorinator.mode == ChlorinatorMode.ORP_AUTO
 
     @property
     def native_value(self) -> float | None:

--- a/custom_components/omnilogic_local/sensor.py
+++ b/custom_components/omnilogic_local/sensor.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Literal, cast
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Callable, cast
 
-from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorEntityDescription, SensorStateClass
 from homeassistant.const import CONCENTRATION_PARTS_PER_MILLION, UnitOfPower, UnitOfTemperature
 from pyomnilogic_local import CSAD, Backyard, Bow, Chlorinator, Filter, HeaterEquipment, Sensor
-from pyomnilogic_local.omnitypes import ChlorinatorDispenserType, CSADType, FilterState, HeaterType, SensorType
+from pyomnilogic_local.omnitypes import ChlorinatorDispenserType, CSADMode, FilterState, HeaterType, SensorType
 
 from .const import BACKYARD_SYSTEM_ID, DOMAIN, KEY_COORDINATOR
 from .entity import OmniLogicEntity
+from .typing import OmniLogicEquipment
 
 if TYPE_CHECKING:
     from datetime import date, datetime
@@ -23,6 +25,100 @@ if TYPE_CHECKING:
     from .coordinator import OmniLogicCoordinator
 
 _LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, kw_only=True)
+class OmniLogicSensorEntityDescription(SensorEntityDescription):
+    """Describes an OmniLogic binary sensor entity"""
+
+    extra_state_attributes_fn: Callable[[OmniLogicEquipment], dict[str, Any]] = field(default_factory=lambda: lambda _: {})
+    value_fn: Callable[[OmniLogicEquipment], bool | float | int | str | None]
+
+
+FILTER_SENSORS: tuple[OmniLogicSensorEntityDescription, ...] = (
+    OmniLogicSensorEntityDescription(
+        key="filter_power",
+        name="Power",
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        value_fn=lambda equipment: (
+            equipment.power
+            if isinstance(equipment, Filter)
+            and equipment.state
+            in [
+                FilterState.ON,
+                FilterState.PRIMING,
+                FilterState.HEATER_EXTEND,
+                FilterState.CSAD_EXTEND,
+                FilterState.FORCE_PRIMING,
+                FilterState.SUPERCHLORINATE,
+            ]
+            else 0
+        ),
+    ),
+)
+
+CHLORINATOR_SALT_SENSORS: tuple[OmniLogicSensorEntityDescription, ...] = (
+    OmniLogicSensorEntityDescription(
+        key="chlorinator_salt_level_average",
+        name="Average Salt Level",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
+        value_fn=lambda equipment: equipment.avg_salt_level if isinstance(equipment, Chlorinator) else None,
+    ),
+    OmniLogicSensorEntityDescription(
+        key="chlorinator_salt_level_instant",
+        name="Instant Salt Level",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
+        value_fn=lambda equipment: equipment.instant_salt_level if isinstance(equipment, Chlorinator) else None,
+    ),
+)
+
+CSAD_SENSORS: tuple[OmniLogicSensorEntityDescription, ...] = (
+    OmniLogicSensorEntityDescription(
+        key="csad_ph",
+        name="pH",
+        device_class=SensorDeviceClass.PH,
+        state_class=SensorStateClass.MEASUREMENT,
+        extra_state_attributes_fn=lambda equipment: (
+            {
+                "omni_target_value": equipment.ph_target_level,
+                "omni_value_raw": equipment.ph_current_value_raw,
+                "omni_calibration_value": equipment.ph_calibration_value,
+                "omni_low_alarm_value": equipment.ph_low_alarm_level,
+                "omni_high_alarm_value": equipment.ph_high_alarm_level,
+            }
+            if isinstance(equipment, CSAD)
+            else {}
+        ),
+        value_fn=lambda equipment: equipment.ph_current_value if isinstance(equipment, CSAD) else None,
+    ),
+    OmniLogicSensorEntityDescription(
+        key="csad_orp",
+        name="ORP",
+        state_class=SensorStateClass.MEASUREMENT,
+        extra_state_attributes_fn=lambda equipment: (
+            {
+                "omni_target_value": equipment.orp_target_level,
+                "omni_runtime_level": equipment.orp_runtime_level,
+                "omni_low_alarm_value": equipment.orp_low_alarm_level,
+                "omni_high_alarm_value": equipment.orp_high_alarm_level,
+            }
+            if isinstance(equipment, CSAD)
+            else {}
+        ),
+        value_fn=lambda equipment: equipment.orp_current_level if isinstance(equipment, CSAD) else None,
+    ),
+    OmniLogicSensorEntityDescription(
+        key="csad_mode",
+        name="Mode",
+        device_class=SensorDeviceClass.ENUM,
+        options=[str(mode) for mode in CSADMode],
+        value_fn=lambda equipment: str(equipment.mode) if isinstance(equipment, CSAD) else None,
+    ),
+)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
@@ -77,17 +173,26 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 
     # Create energy sensors for filters suitable for inclusion in the energy dashboard
     for _, _, filt in coordinator.omni.all_filters.items():
-        entities.append(OmniLogicFilterEnergySensorEntity(coordinator=coordinator, equipment=filt))
+        entities.extend(
+            OmniLogicSensorEntity[Filter](
+                coordinator=coordinator,
+                equipment=filt,
+                entity_description=description,
+            )
+            for description in FILTER_SENSORS
+        )
 
     # Create salt level sensors for chlorinators
     for _, _, chlorinator in coordinator.omni.all_chlorinators.items():
         match chlorinator.dispenser_type:
             case ChlorinatorDispenserType.SALT:
-                entities.append(
-                    OmniLogicChlorinatorSaltLevelSensorEntity(coordinator=coordinator, equipment=chlorinator, sensor_type="average")
-                )
-                entities.append(
-                    OmniLogicChlorinatorSaltLevelSensorEntity(coordinator=coordinator, equipment=chlorinator, sensor_type="instant")
+                entities.extend(
+                    OmniLogicSensorEntity[Chlorinator](
+                        coordinator=coordinator,
+                        equipment=chlorinator,
+                        entity_description=description,
+                    )
+                    for description in CHLORINATOR_SALT_SENSORS
                 )
             case ChlorinatorDispenserType.LIQUID:
                 # It looks like there are no liquid sensors exposed in the telemetry
@@ -99,10 +204,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 
     # Create pH and ORP sensors for CSAD systems
     for _, _, csad in coordinator.omni.all_csads.items():
-        match csad.equip_type:
-            case CSADType.ACID | CSADType.CO2:
-                entities.append(OmniLogicCSADAcidPhEntity(coordinator=coordinator, equipment=csad))
-                entities.append(OmniLogicCSADAcidORPEntity(coordinator=coordinator, equipment=csad))
+        entities.extend(
+            OmniLogicSensorEntity[CSAD](
+                coordinator=coordinator,
+                equipment=csad,
+                entity_description=description,
+            )
+            for description in CSAD_SENSORS
+        )
 
     async_add_entities(entities)
 
@@ -187,99 +296,23 @@ class OmniLogicSolarTemperatureSensorEntity(OmniLogicTemperatureSensorEntity[Hea
         return temp if temp not in [-1, 255, 65535] else None
 
 
-class OmniLogicFilterEnergySensorEntity(OmniLogicEntity[Filter], SensorEntity):
-    """Sensor entity for filter power consumption."""
+class OmniLogicSensorEntity[EquipmentType: OmniLogicEquipment](OmniLogicEntity[EquipmentType], SensorEntity):
+    entity_description: OmniLogicSensorEntityDescription
 
-    _attr_device_class = SensorDeviceClass.POWER
-    _attr_native_unit_of_measurement = UnitOfPower.WATT
-    _attr_state_class = SensorStateClass.MEASUREMENT
-
-    @property
-    def native_value(self) -> StateType | date | datetime | Decimal:
-        return (
-            self.equipment.power
-            if self.equipment.state
-            in [
-                FilterState.ON,
-                FilterState.PRIMING,
-                FilterState.HEATER_EXTEND,
-                FilterState.CSAD_EXTEND,
-                FilterState.FILTER_FORCE_PRIMING,
-                FilterState.FILTER_SUPERCHLORINATE,
-            ]
-            else 0
-        )
-
-    @property
-    def name(self) -> str:
-        return f"{self.equipment.name} Power"
-
-
-class OmniLogicChlorinatorSaltLevelSensorEntity(OmniLogicEntity[Chlorinator], SensorEntity):
-    """Sensor entity for chlorinator salt level readings."""
-
-    _attr_native_unit_of_measurement = CONCENTRATION_PARTS_PER_MILLION
-    _attr_state_class = SensorStateClass.MEASUREMENT
-    _sensor_type: Literal["average", "instant"]
-
-    def __init__(self, coordinator: OmniLogicCoordinator, equipment: Chlorinator, sensor_type: Literal["average", "instant"]) -> None:
+    def __init__(
+        self,
+        coordinator: OmniLogicCoordinator,
+        equipment: EquipmentType,
+        entity_description: OmniLogicSensorEntityDescription,
+    ) -> None:
         super().__init__(coordinator, equipment)
-        self._sensor_type = sensor_type
-
-    @property
-    def native_value(self) -> StateType | date | datetime | Decimal:
-        match self._sensor_type:
-            case "average":
-                return self.equipment.avg_salt_level
-            case "instant":
-                return self.equipment.instant_salt_level
-
-    @property
-    def name(self) -> str:
-        return f"{self.equipment.name} {self._sensor_type.capitalize()} Salt Level"
-
-
-class OmniLogicCSADAcidPhEntity(OmniLogicEntity[CSAD], SensorEntity):
-    """Sensor entity for CSAD acid pH level readings."""
-
-    _attr_device_class = SensorDeviceClass.PH
-    _attr_state_class = SensorStateClass.MEASUREMENT
-
-    @property
-    def native_value(self) -> StateType | date | datetime | Decimal:
-        # ph_current_value already includes the calibration value, so we can just return it directly
-        return self.equipment.ph_current_value
+        self.entity_description = entity_description
+        self._attr_name = f"{equipment.name} {entity_description.name}" if hasattr(entity_description, "name") else None
 
     @property
     def _extra_state_attributes(self) -> dict[str, Any]:
-        return {
-            "omni_orp": self.equipment.orp_current_level,
-            "omni_mode": str(self.equipment.mode),
-            "omni_target_value": self.equipment.ph_target_level,
-            "omni_ph_value_raw": self.equipment.ph_current_value_raw,
-            "omni_calibration_value": self.equipment.ph_calibration_value,
-            "omni_ph_low_alarm_value": self.equipment.ph_low_alarm_level,
-            "omni_ph_high_alarm_value": self.equipment.ph_high_alarm_level,
-        }
-
-
-class OmniLogicCSADAcidORPEntity(OmniLogicEntity[CSAD], SensorEntity):
-    """Sensor entity for CSAD ORP level readings."""
-
-    _attr_state_class = SensorStateClass.MEASUREMENT
-    _attr_name = "ORP"
+        return self.entity_description.extra_state_attributes_fn(self.equipment)
 
     @property
-    def native_value(self) -> StateType | date | datetime | Decimal:
-        return self.equipment.orp_current_level
-
-    @property
-    def _extra_state_attributes(self) -> dict[str, Any]:
-        return {
-            "omni_target_level": self.equipment.orp_target_level,
-            "omni_runtime_level": self.equipment.orp_runtime_level,
-            "omni_low_alarm_level": self.equipment.orp_low_alarm_level,
-            "omni_high_alarm_level": self.equipment.orp_high_alarm_level,
-            "omni_forced_on_time": self.equipment.orp_forced_on_time,
-            "omni_forced_enabled": self.equipment.orp_forced_enabled,
-        }
+    def native_value(self) -> bool | float | int | str | None:
+        return self.entity_description.value_fn(self.equipment)

--- a/custom_components/omnilogic_local/switch.py
+++ b/custom_components/omnilogic_local/switch.py
@@ -140,6 +140,15 @@ class OmniLogicChlorinatorSwitchEntity(OmniLogicSwitchEntity[Chlorinator]):
     def icon(self) -> str | None:
         return "mdi:toggle-switch-variant" if self.is_on else "mdi:toggle-switch-variant-off"
 
+    @property
+    def _extra_state_attributes(self) -> dict[str, Any]:
+        return {
+            "omni_operating_state": str(self.equipment.operating_state),
+            "omni_operating_mode": str(self.equipment.operating_mode),
+            "omni_mode": str(self.equipment.mode),
+            "omni_dispenser_type": str(self.equipment.dispenser_type),
+        }
+
 
 class OmniLogicGroupSwitchEntity(OmniLogicSwitchEntity[Group]):
     """Switch entity for groups."""

--- a/uv.lock
+++ b/uv.lock
@@ -329,15 +329,15 @@ wheels = [
 
 [[package]]
 name = "python-omnilogic-local"
-version = "3.1.0"
+version = "5.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "xmltodict" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b8/52/d4fc0385e6a60e3d6e4c1691067816689324e88920adab6f17479ac8a4f0/python_omnilogic_local-3.1.0.tar.gz", hash = "sha256:fab74177333bc641c3e4f724a4be9e725c10d2817b9e227ce1217d942948cc17", size = 84755, upload-time = "2026-05-12T04:22:22.936Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/bf/0c7f0e116f0f9589cf006a8c9e05b253e269a49c8b6fd19c6b51e6327f8d/python_omnilogic_local-5.0.0.tar.gz", hash = "sha256:cf5cc627e550a697ad6ab04159344721e556e1e9ac8218774eb3ff9aa851c300", size = 85937, upload-time = "2026-05-29T15:58:54.9Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/30/23bacb05b0d5be26edf52b4d23c358593e5d12cf95fa2b254e64bdb87fdc/python_omnilogic_local-3.1.0-py3-none-any.whl", hash = "sha256:dc0608edc4fbe0796f0f31b3792e522ceedb2ee0934b497ee59fcd445f834a7a", size = 119357, upload-time = "2026-05-12T04:22:21.105Z" },
+    { url = "https://files.pythonhosted.org/packages/64/e2/e59b1281457eaf46ec8e5980c874dee2b00fbd201eab1722fc0166597f2d/python_omnilogic_local-5.0.0-py3-none-any.whl", hash = "sha256:99c3d78ece4c9906e9116d73add4ac3071e016103a0856c466c453cda724057a", size = 120601, upload-time = "2026-05-29T15:58:53.58Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Update python-omnilogic-local library to v5.0.0 (fixes #261)
- Use new config object in underlying library
- Silence warnings about equipment with duplicate names (fixes #261)
- Update equipment data enums to better follow OmniLogic naming
- Disable timed-percent/orp number entities by default depending on current mode
  - This only applies when the integration is first set up
- Refactor sensor.py to use EntityDescriptions for better sustainability