### PR TITLE
fix(omnilogic_local): prevent permanent crash-loop and unavailable flapping (#234)

### DIFF
--- a/custom_components/omnilogic_local/const.py
+++ b/custom_components/omnilogic_local/const.py
@@ -11,6 +11,11 @@ KEY_COORDINATOR: Final[str] = "coordinator"
 SCAN_INTERVAL = timedelta(seconds=10)
 UPDATE_DELAY_SECONDS: Final[float] = 1.5
 
+# The Omni communicates over UDP, which is lossy - especially over WiFi. A single
+# dropped/late poll should not flip every entity to unavailable. Tolerate this many
+# consecutive failed polls (keeping last-known data) before surfacing UpdateFailed.
+MAX_CONSECUTIVE_UPDATE_FAILURES: Final[int] = 3
+
 # According to Hayward docs, the backyard always has a system id of 0
 BACKYARD_SYSTEM_ID: Final[int] = 0
 

--- a/custom_components/omnilogic_local/coordinator.py
+++ b/custom_components/omnilogic_local/coordinator.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import SCAN_INTERVAL, UPDATE_DELAY_SECONDS
+from .const import MAX_CONSECUTIVE_UPDATE_FAILURES, SCAN_INTERVAL, UPDATE_DELAY_SECONDS
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -37,6 +37,7 @@ class OmniLogicCoordinator(DataUpdateCoordinator[None]):
             update_interval=SCAN_INTERVAL,
         )
         self.omni = omni
+        self._consecutive_failures = 0
 
     async def _async_update_data(self) -> None:
         """Update data via library."""
@@ -48,7 +49,20 @@ class OmniLogicCoordinator(DataUpdateCoordinator[None]):
         except Exception as err:
             err_name = type(err).__name__
             self.failure_counts[err_name] = self.failure_counts.get(err_name, 0) + 1
-            raise UpdateFailed("Failed to update data from OmniLogic") from err
+            self._consecutive_failures += 1
+            # The Omni talks UDP (lossy over WiFi); don't flip every entity to unavailable
+            # on a single dropped/late poll. Keep last-known data until we cross the
+            # threshold of consecutive failures, then surface UpdateFailed.
+            if self._consecutive_failures >= MAX_CONSECUTIVE_UPDATE_FAILURES:
+                raise UpdateFailed("Failed to update data from OmniLogic") from err
+            _LOGGER.debug(
+                "OmniLogic poll failed (%d/%d consecutive), keeping last-known data: %s",
+                self._consecutive_failures,
+                MAX_CONSECUTIVE_UPDATE_FAILURES,
+                err_name,
+            )
+            return
+        self._consecutive_failures = 0
 
     def do_next_refresh_after(self, delay: float = UPDATE_DELAY_SECONDS) -> None:
         """Delay the next refresh by a given number of seconds."""

--- a/custom_components/omnilogic_local/entity.py
+++ b/custom_components/omnilogic_local/entity.py
@@ -28,6 +28,10 @@ class OmniLogicEntity[EquipmentTypes: OmniLogicEquipment](CoordinatorEntity[Omni
     ) -> None:
         super().__init__(coordinator=coordinator)
         self.equipment = equipment
+        # Tracks whether this entity's equipment was present in the latest telemetry
+        # frame. We never overwrite self.equipment with None (see _handle_coordinator_update),
+        # so every dereference stays safe; availability is driven by this flag instead.
+        self._equipment_available = True
         self.bow_id = equipment.bow_id
         self.system_id = equipment.system_id
         subclass_name = self.__class__.__name__
@@ -37,18 +41,30 @@ class OmniLogicEntity[EquipmentTypes: OmniLogicEquipment](CoordinatorEntity[Omni
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         if self.system_id is not None:
-            subclass_name = self.__class__.__name__
-            _LOGGER.debug(
-                "Updating %s for %s - SystemID: %s, Name: %s", subclass_name, self.equipment.omni_type, self.system_id, self.equipment.name
-            )
-            self.equipment = cast("EquipmentTypes", self.coordinator.omni.get_equipment_by_id(self.system_id))
+            # Equipment can be temporarily missing from a telemetry frame (transient
+            # comms gap) or genuinely absent. In that case keep the last-known object
+            # rather than storing None, so name/device_info/attributes never dereference
+            # None (which previously left the entity permanently stuck throwing every
+            # poll). Availability is signalled via _equipment_available instead.
+            equipment = self.coordinator.omni.get_equipment_by_id(self.system_id)
+            self._equipment_available = equipment is not None
+            if equipment is not None:
+                self.equipment = cast("EquipmentTypes", equipment)
+                _LOGGER.debug(
+                    "Updating %s for %s - SystemID: %s, Name: %s",
+                    self.__class__.__name__,
+                    self.equipment.omni_type,
+                    self.system_id,
+                    self.equipment.name,
+                )
         self.async_write_ha_state()
 
     @property
     def available(self) -> bool:
         # By default we consider an entity available if the backyard is ready (not in service mode),
         # Individual entities can override this if needed.
-        return super().available and self.equipment._omni.backyard.is_ready  # Ensure coordinator is available, which checks if we have data
+        # If this entity's equipment was missing from the latest telemetry, treat it as unavailable.
+        return super().available and self._equipment_available and self.equipment._omni.backyard.is_ready
 
     @cached_property
     def device_info(self) -> DeviceInfo | None:


### PR DESCRIPTION
Fixes two related bugs that make OmniLogic entities go unavailable — one leaves entities permanently stuck (until a restart), the other flaps every entity unavailable on a single failed poll. Together these are the likely cause of #234. 

**Bug 1** — entity permanently stuck after a missing telemetry frame
OmniLogicEntity._handle_coordinator_update dereferences self.equipment.omni_type (in a debug log) BEFORE re-fetching self.equipment:

if self.system_id is not None:
    _LOGGER.debug("Updating %s for %s ...", ..., self.equipment.omni_type, ...)  # OLD equipment
    self.equipment = cast("EquipmentTypes", self.coordinator.omni.get_equipment_by_id(self.system_id))
When get_equipment_by_id() returns None for a poll (the system_id isn't in that telemetry frame), self.equipment is set to None. On the NEXT poll the debug line raises AttributeError before the recovery re-fetch on the following line runs, so the entity never recovers and throws on every poll until HA restarts. available has the same latent NPE (self.equipment._omni...).

Observed live, repeating every ~10s (the poll interval):
ERROR (MainThread) [custom_components.omnilogic_local.coordinator] Unexpected error updating listener 545362472448 for OmniLogic
Traceback (most recent call last):
  File ".../homeassistant/helpers/update_coordinator.py", line 202, in async_update_listeners
    update_callback()
  File ".../custom_components/omnilogic_local/entity.py", line 42, in _handle_coordinator_update
    "Updating %s for %s - SystemID: %s, Name: %s", subclass_name, self.equipment.omni_type, self.system_id, self.equipment.name
AttributeError: 'NoneType' object has no attribute 'omni_type'
In my system this permanently stuck two entities whose system_id is never resolved by get_equipment_by_id: the backyard "Restore Idle" button (system_id 0) and the spa water-temp sensor (system_id 16). get_equipment_by_id matches equipment.system_id == system_id across a fixed equipment list, so any id not present there returns None on every poll — meaning the crash affects both transient telemetry gaps and permanently-unresolvable entities. (Whether those two should resolve looks like a separate id-mapping issue, out of scope here.)

A user-visible side effect: stateless button entities log phantom "Pressed" events, because the frontend renders each availability flap as a press — so an unavailable→recover cycle on button.omnilogic_backyard_restore_idle looks like someone pressed "Restore Idle" when nothing was ever sent to the controller.

Fix: never store None. Keep the last-known equipment object and track presence in a new _equipment_available flag that drives available. No dereference can hit None, and the entity auto-recovers when its system_id reappears in telemetry.

**Bug 2** — all entities flap unavailable on a single failed poll
OmniLogicCoordinator._async_update_data raised UpdateFailed on ANY exception, so one failed telemetry poll flips EVERY entity unavailable for that cycle, recovering on the next successful poll.

Observed from recorder history: all OmniLogic entities transitioned to unavailable simultaneously and recovered together on the next successful poll (clean DataUpdateCoordinator all-at-once signature).

Fix: tolerate up to MAX_CONSECUTIVE_UPDATE_FAILURES (3) consecutive failed polls on last-known data before raising UpdateFailed. With the 10s poll interval that rides out ~20-30s before showing unavailable; a genuine stall still surfaces within ~30s.

Background — most "unavailable" episodes are panel-side, not the network
Diagnosis on a live, HARD-WIRED install showed the "unavailable" episodes are not network or HA problems — they are the OmniLogic controller's local UDP API not answering while the box stays fully reachable:

Uptime Kuma pinging the panel every 60s recorded <1ms response and 100% uptime straight through the outage windows — no ICMP loss at all.
Each poll opens and closes its own UDP datagram endpoint (api.async_send_and_receive), so ~39 consecutive independent sockets failing cannot be a wedged local socket.
No HA restart during the spontaneous stalls; every other integration kept working.
Therefore the controller's local API responder stops servicing RequestTelemetryData for a period (each fresh request hits the retransmit → OmniTimeoutError path) while its network stack stays up. Over a week these stalls recurred ~daily, always in the evening (pool/spa in use, Hayward app/cloud most likely connected), with wildly varying duration (12s, 0.9min, 6.5min). A separate mode was observed after an HA restart: the integration set up entities but could not obtain a single successful telemetry poll for ~2 hours (the panel appears to hold the prior client session until it times out).

These patches do NOT try to mask that — a multi-minute panel stall SHOULD surface as unavailable. Bug 2's tolerance only smooths sub-30s blips; Bug 1's fix stops the permanent crash-loop that a missing frame would otherwise trigger. The root panel behavior (single-session local API contention / responder hangs) is out of scope for these code changes.

Changes
entity.py — keep last-known equipment; add _equipment_available; guard available.
coordinator.py — consecutive-failure tolerance; reset counter on success.
const.py — add MAX_CONSECUTIVE_UPDATE_FAILURES = 3.

**Testing**
Diagnosed and verified on a live HAOS instance (integration 2.0.0, python-omnilogic-local 5.0.0), hard-wired to the controller (ethernet).

Bug 1 — crash loop (verified via restart)
Before: the AttributeError above repeated every ~10 s (the poll interval) for two entities whose system_id never resolves via get_equipment_by_id — the backyard "Restore Idle" button (system_id 0) and the spa water-temp sensor (system_id 16) — and they stayed stuck until a restart.

After the patch + restart:

The omni_type crash loop is gone — no recurrence beyond the old process's final polls during the restart transition; steady-state logs are clean.
The two previously-stuck entities now sit in clean resting states (button unknown; sensor unknown while the spa pump is off) instead of throwing on every poll.
All other OmniLogic entities (pump, heaters, valves, pool water sensor, etc.) report normally; the integration set up without errors and ha core check passes.
Bug 2 — failure tolerance (verified by simulating outages)
Simulated controller-unreachable outages by blocking the panel at the switch (UniFi client block), which makes the UDP telemetry poll fail without touching the panel's power, then watched entity availability and the coordinator log:

Tolerance — ~20 s block (2 missed polls): zero entities flipped to unavailable; they held last-known data throughout and resumed cleanly on unblock. (Pre-fix, a single missed poll flips everything.)
Threshold — ~30 s+ block (≥3 missed polls): entities stayed available through the first two failures, then on the 3rd consecutive failure the coordinator raised UpdateFailed (ERROR ... Failed to update data from OmniLogic) and all 31 entities went unavailable together — ~30 s into the outage, not on the first poll.
Recovery: on unblock, all entities recovered on the next successful poll (~32 s total downtime), with no lingering session hang.
Net effect: transient sub-30 s telemetry gaps no longer flap every entity unavailable, while genuine multi-poll outages still surface as unavailable as they should.